### PR TITLE
Consertando título na folha de aprovação

### DIFF
--- a/projetofinal-dcc.cls
+++ b/projetofinal-dcc.cls
@@ -247,7 +247,11 @@
     \clearpage
     \thispagestyle{empty}
     \bigskip
-    \centerline{\textbf{\large\@title}}
+    \begingroup
+      \leftskip=0cm plus 0.5fil \rightskip=0cm plus -0.5fil
+      \parfillskip=0cm plus 1fil
+      \textbf{\large\@title}\par
+    \endgroup
     \bigskip
     \centerline{\textbf{\@authora}}
     \@ifundefined{@authorb}{}{


### PR DESCRIPTION
Na minha monografia, o título ficou grande demais para caber em apenas uma linha. O comando \centerline não permite a quebra de linhas, logo mudei para um ambiente mais personalizado no título.
